### PR TITLE
fixed VS Code workspace file after v9 upate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The [LVGL](https://github.com/lvgl/lvgl) is written mainly for microcontrollers 
 ## Requirements
 This project is configured for [VSCode](https://code.visualstudio.com) and only tested on Linux, although this may work on OSx or WSL. It requires a working version of GCC, GDB and make in your path.
 
-To allow debugging inside VSCode you will also require a GDB [extension](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) or other suitable debugger. All the requirements have been pre-configured in the [.workspace](simulator.code-workspace) file (simply open the project by doubleclick on this file).
+To allow debugging inside VSCode you will also require a GDB [extension](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) or other suitable debugger. All the requirements, build and debug settings have been pre-configured in the [.workspace](simulator.code-workspace) file (simply open the project by doubleclick on this file).
 
 The project can use **SDL** but it can be easily relaced by any other built-in LVGL dirvers.
 
@@ -20,7 +20,7 @@ git clone --recursive https://github.com/lvgl/lv_port_pc_vscode
 ```
 
 ### Install graphics driver
- 
+
 Please make sure **SDL**  is installed in the system:
 
 #### Install SDL

--- a/simulator.code-workspace
+++ b/simulator.code-workspace
@@ -23,13 +23,7 @@
 		"files.trimTrailingWhitespace": true,
 		"files.insertFinalNewline": true,
 		"files.trimFinalNewlines": true,
-		"cmake.configureOnOpen": false,
-		"files.associations": {
-			"lv_demos.h": "c",
-			"lvgl.h": "c",
-			"lv_drv_conf.h": "c",
-			"stdlib.h": "c"
-		},
+		"cmake.configureOnOpen": true,
 	},
 	// tasks.json section
 	"tasks": {
@@ -68,7 +62,7 @@
 				"name": "Debug LVGL demo with gdb",
 				"type": "cppdbg",
 				"request": "launch",
-			        "program": "bin/main",
+		        "program": "${workspaceFolder}/bin/main",
 				"args": [],
 				"cwd": "${workspaceFolder}",
 				"preLaunchTask": "Build",

--- a/simulator.code-workspace
+++ b/simulator.code-workspace
@@ -13,6 +13,7 @@
 		"recommendations": [
 			"ms-vscode.cpptools",              // common C/C++ support
 			"ms-vscode.cpptools-themes",       // general C/C++ theme
+			"ms-vscode.cmake-tools"            // cmake support
 		],
 		"unwantedRecommendations": [
 		]
@@ -36,7 +37,10 @@
 		"tasks": [
 			{
 				"label": "Build",
-				"command": "make",
+				"command": "cmake",
+				"args": [
+					"--build", "${command:cmake.buildDirectory}"
+				],
 				"group": {
 					"kind": "build",
 					"isDefault": true
@@ -64,9 +68,9 @@
 				"name": "Debug LVGL demo with gdb",
 				"type": "cppdbg",
 				"request": "launch",
-			        "program": "${workspaceFolder}/build/bin/demo",
+			        "program": "bin/main",
 				"args": [],
-				"cwd": "${fileDirname}",
+				"cwd": "${workspaceFolder}",
 				"preLaunchTask": "Build",
 				"stopAtEntry": false,
 			},


### PR DESCRIPTION
- fixed the make command (use cmake --build instead of make to be independent from cmake generator)
- fixed launched executable filename
- added recommendation for cmake extension