### PR TITLE
fix(lldb) Configured launch.json to use LLDB in macOS and gdb in linux/Windows

### DIFF
--- a/simulator.code-workspace
+++ b/simulator.code-workspace
@@ -77,6 +77,17 @@
 				"cwd": "${workspaceFolder}",
 				"preLaunchTask": "Build",
 				"stopAtEntry": false,
+				"linux": {
+					"MIMode": "gdb",
+					"miDebuggerPath": "/usr/bin/gdb"
+				  },
+				  "osx": {
+					"MIMode": "lldb"
+				  },
+				  "windows": {
+					"MIMode": "gdb",
+					"miDebuggerPath": "C:\\MinGw\\bin\\gdb.exe"
+				  }
 			},
 			{
 				"name": "Debug LVGL demo with LLVM",
@@ -87,6 +98,7 @@
 				"cwd": "${workspaceFolder}",
 				"preLaunchTask": "Build",
 				"stopAtEntry": false,
+				"MIMode": "lldb"
 			},
 		],
 	},


### PR DESCRIPTION
Description of the feature or fix

Since lldb-mi is not present in macOS we can use the default lldb to launch debug.
Added linux/windows support for gdb