### PR TITLE
remove leak option for fsanitize to support macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         -Wstrict-aliasing
     )
 
-    target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
-    target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
+    target_compile_options(main PRIVATE -fsanitize=address,undefined)
+    target_link_options(main PRIVATE -fsanitize=address,undefined)
 endif()


### PR DESCRIPTION
when building this on macos:

```
clang: error: unsupported option '-fsanitize=leak' for target 'arm64-apple-darwin23.5.0'
make[2]: *** [CMakeFiles/main.dir/main/src/main.c.o] Error 1
make[1]: *** [CMakeFiles/main.dir/all] Error 2
make: *** [all] Error 2
```

this pr removes the leak flag which enables the build to succeed
