### PR TITLE
Fix unsupported leak sanitizer in apple arm64 environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         -Wstrict-aliasing
     )
 
-    target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
-    target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        target_compile_options(main PRIVATE -fsanitize=address,undefined)
+        target_link_options(main PRIVATE -fsanitize=address,undefined)
+    else()
+        target_compile_options(main PRIVATE -fsanitize=address,leak,undefined)
+        target_link_options(main PRIVATE -fsanitize=address,leak,undefined)
+    endif()
 endif()


### PR DESCRIPTION
This change is to add support for M Series Macbooks as they currently dont have the leak option in clang

error message:
>clang: error: unsupported option '-fsanitize=leak' for target 'arm64-apple-darwin23.5.0'

after change the sample program will build fine
