### PR TITLE
[BUGFIX]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(lvgl C CXX)
 # Set the correct FreeRTOS port for your system (e.g., Posix for WSL)
 set(FREERTOS_PORT GCC_POSIX CACHE STRING "Port for FreeRTOS on Posix environment")
 
-option(USE_FREERTOS "Enable FreeRTOS" OFF) # Turn this on to enable FreeRTOS 
+unset(USE_FREERTOS CACHE)
+
+option(USE_FREERTOS "Enable FreeRTOS" OFF) # Turn this on to enable FreeRTOS
 
 if(USE_FREERTOS)
     message(STATUS "FreeRTOS is enabled")
@@ -175,4 +177,3 @@ else()
     message(STATUS "AddressSanitizer disabled")
 endif()
 endif()
-


### PR DESCRIPTION
Add the unset before the option makes the USE_FREERTOS variable active with its current value