### PR TITLE
Fixed build error in case of FreeRtos configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(USE_FREERTOS)
         ${FREERTOS_SOURCES}  # Add only if USE_FREERTOS is enabled
     )
     # Link FreeRTOS libraries
-    target_link_libraries(main freertos_config FreeRTOS)
+    target_link_libraries(main freertos_config freertos_kernel)
 else()
     add_executable(main
         ${PROJECT_SOURCE_DIR}/main/src/main.c

--- a/config/FreeRTOSConfig.h
+++ b/config/FreeRTOSConfig.h
@@ -34,7 +34,7 @@ extern uint32_t SystemCoreClock;
 #define configUSE_APPLICATION_TASK_TAG          0
 #define configUSE_COUNTING_SEMAPHORES           1
 #define configGENERATE_RUN_TIME_STATS           0
-#define configUSE_TASK_NOTIFICATIONS            0
+#define configUSE_TASK_NOTIFICATIONS            1
 #define configUSE_STREAM_BUFFERS                0
 
 /* Co-routine definitions. */

--- a/main/src/freertos_main.cpp
+++ b/main/src/freertos_main.cpp
@@ -175,13 +175,13 @@ extern "C" void freertos_main()
     /* Initialize LVGL (Light and Versatile Graphics Library) and other resources */
 
     /* Create the LVGL task */
-    if (xTaskCreate(lvgl_task, "LVGL Task", 4096, nullptr, 1, nullptr) != pdPASS) {
+    if (xTaskCreate(lvgl_task, "LVGL Task", 4096, nullptr, 3, nullptr) != pdPASS) {
         printf("Error creating LVGL task\n");
         /* Error handling */
     }
 
     /* Create another task */
-    if (xTaskCreate(another_task, "Another Task", 1024, nullptr, 1, nullptr) != pdPASS) {
+    if (xTaskCreate(another_task, "Another Task", 1024, nullptr, 3, nullptr) != pdPASS) {
         printf("Error creating another task\n");
         /* Error handling */
     }

--- a/main/src/freertos_main.cpp
+++ b/main/src/freertos_main.cpp
@@ -13,6 +13,12 @@
 #include "lvgl.h"
 #include <cstdio>  // For printf in C++
 
+/**
+ * Initialize the Hardware Abstraction Layer (HAL) for the LVGL graphics
+ * library
+ */
+static lv_display_t * hal_init(int32_t w, int32_t h);
+
 // ........................................................................................................
 /**
  * @brief   Malloc failed hook
@@ -119,6 +125,14 @@ void create_hello_world_screen()
  */
 void lvgl_task(void *pvParameters)
 {
+    /* Initialize LVGL*/
+    /* When USE_FREERTOS_TASK_NOTIFY rtos param is configured
+     * we shall initialize lvgl in a task context o
+     */
+    lv_init();
+
+    /*Initialize the HAL (display, input devices, tick) for LVGL*/
+    hal_init(320, 480);
     /* Show simple hello world screen */
     create_hello_world_screen();
 
@@ -176,4 +190,40 @@ extern "C" void freertos_main()
     vTaskStartScheduler();
 }
 
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+/**
+ * Initialize the Hardware Abstraction Layer (HAL) for the LVGL graphics
+ * library
+ */
+static lv_display_t * hal_init(int32_t w, int32_t h)
+{
+
+  lv_group_set_default(lv_group_create());
+
+  lv_display_t * disp = lv_sdl_window_create(w, h);
+
+  lv_indev_t * mouse = lv_sdl_mouse_create();
+  lv_indev_set_group(mouse, lv_group_get_default());
+  lv_indev_set_display(mouse, disp);
+  lv_display_set_default(disp);
+
+  LV_IMAGE_DECLARE(mouse_cursor_icon); /*Declare the image file.*/
+  lv_obj_t * cursor_obj;
+  cursor_obj = lv_image_create(lv_screen_active()); /*Create an image object for the cursor */
+  lv_image_set_src(cursor_obj, &mouse_cursor_icon);           /*Set the image source*/
+  lv_indev_set_cursor(mouse, cursor_obj);             /*Connect the image  object to the driver*/
+
+  lv_indev_t * mousewheel = lv_sdl_mousewheel_create();
+  lv_indev_set_display(mousewheel, disp);
+  lv_indev_set_group(mousewheel, lv_group_get_default());
+
+  lv_indev_t * kb = lv_sdl_keyboard_create();
+  lv_indev_set_display(kb, disp);
+  lv_indev_set_group(kb, lv_group_get_default());
+
+  return disp;
+}
 #endif

--- a/main/src/main.c
+++ b/main/src/main.c
@@ -34,7 +34,7 @@ static lv_display_t * hal_init(int32_t w, int32_t h);
  *  STATIC VARIABLES
  **********************/
 
-/********************** 
+/**********************
  *      MACROS
  **********************/
 
@@ -69,14 +69,12 @@ int main(int argc, char **argv)
   (void)argc; /*Unused*/
   (void)argv; /*Unused*/
 
+  #if LV_USE_OS == LV_OS_NONE
   /*Initialize LVGL*/
   lv_init();
 
   /*Initialize the HAL (display, input devices, tick) for LVGL*/
   hal_init(320, 480);
-
-  #if LV_USE_OS == LV_OS_NONE
- 
   lv_demo_widgets();
 
   while(1) {
@@ -87,9 +85,8 @@ int main(int argc, char **argv)
   }
 
   #elif LV_USE_OS == LV_OS_FREERTOS
-
   /* Run FreeRTOS and create lvgl task */
-  freertos_main();  
+  freertos_main();
 
   #endif
 


### PR DESCRIPTION
Fixed compilation error in CMakeLists.txt due to
incorrectly specified freeRTOS library.

In case of freetos configuration the lv_init() function shall be called
in a task context.