### PR TITLE
Fix FreeRTOS task freeze race condition, build error, and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(USE_FREERTOS)
         ${FREERTOS_SOURCES}  # Add only if USE_FREERTOS is enabled
     )
     # Link FreeRTOS libraries
-    target_link_libraries(main freertos_config FreeRTOS)
+    target_link_libraries(main freertos_config freertos_kernel)
 else()
     add_executable(main
         ${PROJECT_SOURCE_DIR}/main/src/main.c

--- a/config/FreeRTOSConfig.h
+++ b/config/FreeRTOSConfig.h
@@ -34,7 +34,7 @@ extern uint32_t SystemCoreClock;
 #define configUSE_APPLICATION_TASK_TAG          0
 #define configUSE_COUNTING_SEMAPHORES           1
 #define configGENERATE_RUN_TIME_STATS           0
-#define configUSE_TASK_NOTIFICATIONS            0
+#define configUSE_TASK_NOTIFICATIONS            1
 #define configUSE_STREAM_BUFFERS                0
 
 /* Co-routine definitions. */

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -153,7 +153,7 @@
 /** Stack size of drawing thread.
  * NOTE: If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
  */
-#define LV_DRAW_THREAD_STACK_SIZE    (8 * 1024)         /**< [bytes]*/
+#define LV_DRAW_THREAD_STACK_SIZE    (32 * 1024)         /**< [bytes]*/
 
 /** Thread priority of the drawing task.
  *  Higher values mean higher priority.

--- a/main/src/FreeRTOS_Posix_Port.c
+++ b/main/src/FreeRTOS_Posix_Port.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <time.h>
 
 /* Structure representing an event, consisting of a condition variable and a mutex */
 typedef struct Event
@@ -31,8 +30,8 @@ Event_t *event_create(void)
     Event_t *event = (Event_t *)malloc(sizeof(Event_t));  /* Allocate memory for the event */
     if (event)  /* Check if allocation was successful */
     {
-        pthread_cond_init(&event->cond, NULL);
-        pthread_mutex_init(&event->mutex, NULL);
+        pthread_cond_init(&event->cond, NULL);  /* Initialize the condition variable */
+        pthread_mutex_init(&event->mutex, NULL);  /* Initialize the mutex */
         event->signaled = false;
     }
     return event;  /* Return the created event object */

--- a/main/src/FreeRTOS_Posix_Port.c
+++ b/main/src/FreeRTOS_Posix_Port.c
@@ -7,12 +7,15 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <time.h>
 
 /* Structure representing an event, consisting of a condition variable and a mutex */
 typedef struct Event
 {
     pthread_cond_t cond;      /* Condition variable used to signal the event */
     pthread_mutex_t mutex;    /* Mutex to protect access to the condition variable */
+    bool signaled;   // auto-reset flag to avoid lost wakeups
 } Event_t;
 
 /**
@@ -28,8 +31,9 @@ Event_t *event_create(void)
     Event_t *event = (Event_t *)malloc(sizeof(Event_t));  /* Allocate memory for the event */
     if (event)  /* Check if allocation was successful */
     {
-        pthread_cond_init(&event->cond, NULL);  /* Initialize the condition variable */
-        pthread_mutex_init(&event->mutex, NULL);  /* Initialize the mutex */
+        pthread_cond_init(&event->cond, NULL);
+        pthread_mutex_init(&event->mutex, NULL);
+        event->signaled = false;
     }
     return event;  /* Return the created event object */
 }
@@ -67,6 +71,7 @@ void event_signal(Event_t *event)
     if (event)  /* Check if the event object is valid */
     {
         pthread_mutex_lock(&event->mutex);  /* Lock the mutex before signaling */
+        event->signaled = true;  /* set state first */
         pthread_cond_signal(&event->cond);  /* Signal the condition variable */
         pthread_mutex_unlock(&event->mutex);  /* Unlock the mutex after signaling */
     }
@@ -86,7 +91,10 @@ void event_wait(Event_t *event)
     if (event)  /* Check if the event object is valid */
     {
         pthread_mutex_lock(&event->mutex);  /* Lock the mutex before waiting */
-        pthread_cond_wait(&event->cond, &event->mutex);  /* Wait for the condition variable to be signaled */
+        while (!event->signaled) {  /* guard against spurious wakeups */
+            pthread_cond_wait(&event->cond, &event->mutex);  /* Wait for the condition variable to be signaled */
+        }
+        event->signaled = false;  /* auto-reset */
         pthread_mutex_unlock(&event->mutex);  /* Unlock the mutex after waiting */
     }
 }


### PR DESCRIPTION
When using FreeRTOS, the UI freezes after some time and becomes unresponsive. It was traced to a race condition between the signal and the wait event functions in the POSIX port code and fixed with a guard variable. In addition there were build errors and some LVGL stack size warnings which have been fixed by enabling task notifications and increasing LVGL draw thread stack size. 